### PR TITLE
Accept grant

### DIFF
--- a/cSpell.json
+++ b/cSpell.json
@@ -78,6 +78,7 @@
         "TYPEHASH",
         "typename'Ptr",
         "unvested",
+        "unwithdrawn",
         "visualstudio",
         "vsmarketplacebadge",
         "weth",

--- a/contracts/libraries/VestingVaultStorage.sol
+++ b/contracts/libraries/VestingVaultStorage.sol
@@ -26,6 +26,7 @@ library VestingVaultStorage {
         uint128 cliff;
         uint128 latestVotingPower;
         address delegatee;
+        uint256[2] range;
     }
 
     /// @notice Returns the storage pointer for a named mapping of address to uint256[]

--- a/contracts/vaults/VestingVault.sol
+++ b/contracts/vaults/VestingVault.sol
@@ -130,10 +130,10 @@ contract VestingVault is IVotingVault {
     }
 
     /// @notice Accepts a grant
-    /// @dev sends token from the contract to the sender and back to the contract
+    /// @dev Sends token from the contract to the sender and back to the contract
     /// while assigning a numerical range to the unwithdrawn granted tokens.
     function acceptGrant() public {
-        // load the grant.
+        // load the grant
         VestingVaultStorage.Grant storage grant = _grants()[msg.sender];
         uint256 availableTokens = grant.allocation - grant.withdrawn;
 


### PR DESCRIPTION
accept grant logic withdraws unwithdrawn tokens from the contract to the grantee and back to the contract while setting a range for the tokens. The range is updated on the token claim and should reach 0 on full claim.
Accepting is optional. unaccepted grants do not have a range.
