### PR TITLE
Add changeDelegation to ILockingVault

### DIFF
--- a/contracts/interfaces/ILockingVault.sol
+++ b/contracts/interfaces/ILockingVault.sol
@@ -20,4 +20,8 @@ interface ILockingVault {
 
     /// @notice The token for this locking vault
     function token() external returns (IERC20);
+    
+    /// @notice Changes a user's voting power
+    /// @param newDelegate The new address which gets voting power
+    function changeDelegation(address newDelegate) external;
 }

--- a/contracts/interfaces/ILockingVault.sol
+++ b/contracts/interfaces/ILockingVault.sol
@@ -20,7 +20,7 @@ interface ILockingVault {
 
     /// @notice The token for this locking vault
     function token() external returns (IERC20);
-    
+
     /// @notice Changes a user's voting power
     /// @param newDelegate The new address which gets voting power
     function changeDelegation(address newDelegate) external;

--- a/contracts/vaults/LockingVault.sol
+++ b/contracts/vaults/LockingVault.sol
@@ -170,7 +170,7 @@ abstract contract AbstractLockingVault is IVotingVault, ILockingVault {
 
     /// @notice Changes a user's voting power
     /// @param newDelegate The new address which gets voting power
-    function changeDelegation(address newDelegate) external {
+    function changeDelegation(address newDelegate) external override {
         // Get the stored user data
         Storage.AddressUint storage userData = _deposits()[msg.sender];
         // Get the user balance


### PR DESCRIPTION
Based on previous discussion, this PR adds the `changeDelegation` method to the ILockingVault interface so that we can safely expect all locking vaults to include delegation via this prescribed method name + args.

This was done by copying the `changeDelegation` signature and docblock from here: https://github.com/element-fi/council/blob/main/contracts/vaults/LockingVault.sol

