### PR TITLE
Avoid invalid staleBlock

### DIFF
--- a/contracts/vaults/LockingVault.sol
+++ b/contracts/vaults/LockingVault.sol
@@ -76,12 +76,16 @@ abstract contract AbstractLockingVault is IVotingVault, ILockingVault {
         // Get our reference to historical data
         History.HistoricalBalances memory votingPower = _votingPower();
         // Find the historical data and clear everything more than 'staleBlockLag' into the past
-        return
-            votingPower.findAndClear(
-                user,
-                blockNumber,
-                block.number - staleBlockLag
-            );
+
+        uint256 staleBlock = 0;
+
+        // Though unlikely, staleBlockLag could be set to a number higher than
+        // the current block, especially on a fresh chain like a local testnet.
+        if (staleBlockLag < block.number) {
+            staleBlock = block.number - staleBlockLag;
+        }
+
+        return votingPower.findAndClear(user, blockNumber, staleBlock);
     }
 
     /// @notice Loads the voting power of a user without changing state

--- a/contracts/vaults/VestingVault.sol
+++ b/contracts/vaults/VestingVault.sol
@@ -405,12 +405,16 @@ abstract contract AbstractVestingVault is IVotingVault {
         // Get our reference to historical data
         History.HistoricalBalances memory votingPower = _votingPower();
         // Find the historical data and clear everything more than 'staleBlockLag' into the past
-        return
-            votingPower.findAndClear(
-                user,
-                blockNumber,
-                block.number - staleBlockLag
-            );
+
+        uint256 staleBlock = 0;
+
+        // Though unlikely, staleBlockLag could be set to a number higher than
+        // the current block, especially on a fresh chain like a local testnet.
+        if (staleBlockLag < block.number) {
+            staleBlock = block.number - staleBlockLag;
+        }
+
+        return votingPower.findAndClear(user, blockNumber, staleBlock);
     }
 
     /// @notice Loads the voting power of a user without changing state


### PR DESCRIPTION
While testing on Hardhat, the subtraction of `staleBlockLag` from `block.number` threw "Panic" errors since there weren't enough blocks mined yet.

This change would make it easier to deploy Council to a fresh chain like a local testnet.

We could alternatively add a `require(_staleBlockLag <= block.number, "...")` to the constructor, but then you'd need to adjust your deployment arguments depending on the network and settle for a very short stale block lag when it is a fresh chain. Not sure how to test the effect on gas cost 🤷 

